### PR TITLE
Arm64 Support for VS 2022.

### DIFF
--- a/src/VSThemeColors2022/source.extension.vsixmanifest
+++ b/src/VSThemeColors2022/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
     </Metadata>
     <Installation>
         <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
-            <ProductArchitecture>amd64</ProductArchitecture>
+            <ProductArchitecture>amd64,arm64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
     <Prerequisites>


### PR DESCRIPTION
n/t. Added for '22 only as this is the first version that supports arm64. 